### PR TITLE
missing otherwise case in cleantcp.xsl

### DIFF
--- a/SGML/cleantcp.xsl
+++ b/SGML/cleantcp.xsl
@@ -3593,6 +3593,9 @@
                      </XSL:otherwise>
                   </XSL:choose>
                </XSL:when>
+               <XSL:otherwise>
+                  <XSL:value-of select="."/>
+               </XSL:otherwise>
             </XSL:choose>
          </XSL:matching-substring>
          <XSL:non-matching-substring>


### PR DESCRIPTION
Missing fall-through case caused cleantcp.xsl to drop entity references that preceded in-text semicolons; e.g. "&amp;amp;c;" would be lost altogether. 

For example, compare "Saint Albanes Abbey, Gor­|manchester, &c;"
http://quod.lib.umich.edu/e/eebo/A09192.0001.001/1:6.9?rgn=div2;view=fulltext
http://tei.it.ox.ac.uk/tcp/Texts-HTML/free/A09/A09192.html
